### PR TITLE
Some changes & updates

### DIFF
--- a/blitz.gmap3.js
+++ b/blitz.gmap3.js
@@ -876,6 +876,33 @@ var BlitzMap = new function(){
 
     }
 
+    /*****************************************
+     *
+     * Function replaceOverlays()
+     * This function replaces existing overlays if there's many map instances
+     * parameters:
+     *              divId   : String, Id of HTML DIV element in which the gMap will be created
+     *
+     *****************************************/
+    this.replaceOverlays = function(divId) {
+		divId = divId + "_map"; // override from setMap() - mapDiv.id = divId + "_map";
+		
+		var tmpOverlays = new Array();
+		
+		for( var i=0; i < mapOverlays.length; i++ ) {
+		
+			var m = mapOverlays[i].getMap();
+			var d = m.getDiv();
+			
+			if( divId == d.id ) {
+				tmpOverlays.push( mapOverlays[i] );
+			}
+			
+		}
+
+		mapOverlays = tmpOverlays;
+	}
+
     this.toJSONString = function(){
         var result = JSON.stringify( mapToObject() );
 


### PR DESCRIPTION
When you have many instances of BlitzMap the overlays from all instances are put together in mapOverlays array. I created a function replaceOverlays() to replace mapOverlays array with array of overlays from single map. Its useful when you want to get overlays from one map. I use it in forum when first instance is executed in topic and second instance is executed in reply form.

`First instance`
BlitzMap.setMap('map_canvas1',false,'mapData1'); // map not editable
`Second`
BlitzMap.setMap('map_canvas2',true,'mapData2'); // map editable

`Ajax call`
$.ajax({
beforeSend:function(){
BlitzMap.replaceOverlays( 'map_canvas2' );
BlitzMap.toJSONString();
}
});
